### PR TITLE
fix: update getUpdatedWorkerInfo RPC to use Version instead of Empty

### DIFF
--- a/distributed-sorting/src/main/protobuf/MasterServer.proto
+++ b/distributed-sorting/src/main/protobuf/MasterServer.proto
@@ -40,6 +40,6 @@ message CanShutdownWorkerServerReply {
 service MasterServer {
   rpc register (WorkerInfo) returns (RegisterReply);
   rpc getPartitionRange (SampleKeyData) returns (PartitionRanges);
-  rpc getUpdatedWorkerInfo (google.protobuf.Empty) returns (WorkerInfo);
+  rpc getUpdatedWorkerInfo (Version) returns (WorkerInfo);
   rpc canShutdownWorkerServer (google.protobuf.Empty) returns (CanShutdownWorkerServerReply);
 }


### PR DESCRIPTION
bug fix
getUpdatedWorkerInfo 에 version이 input으로 들어와야 하는데, 그냥 Empty로 놔두었던 것을 수정함