### PR TITLE
fix: change keyDatum and partition range types from string to bytes

### DIFF
--- a/distributed-sorting/src/main/protobuf/MasterServer.proto
+++ b/distributed-sorting/src/main/protobuf/MasterServer.proto
@@ -19,7 +19,7 @@ message RegisterReply {
 
 message SampleKeyData {
   message Key {
-    string keyDatum = 1;
+    bytes keyDatum = 1;
   }
   repeated Key keyData = 1;
 }
@@ -27,8 +27,8 @@ message SampleKeyData {
 message PartitionRanges {
   // [startKey, endKey) === (startKey <= key < endKey)
   message PartitionRange {
-    string startKey = 1;
-    string endKey = 2;
+    bytes startKey = 1;
+    bytes endKey = 2;
   }
   repeated PartitionRange PartitionRanges = 1;
 }


### PR DESCRIPTION
Data가 Byte로 생성시 String type으로는 이를 처리하기 힘들기에 이를 Bytes으로 proto 변경