### PR TITLE
Fix MasterServerProto file because of upgraded register

### DIFF
--- a/distributed-sorting/src/main/protobuf/MasterServer.proto
+++ b/distributed-sorting/src/main/protobuf/MasterServer.proto
@@ -7,6 +7,7 @@ import "google/protobuf/empty.proto";
 message WorkerInfo {
   string ip = 1;
   uint32 port = 2;
+  bool isShuffle = 3;
 }
 message Version {
   uint32 version = 1;
@@ -42,6 +43,6 @@ message CanShutdownWorkerServerReply {
 service MasterServer {
   rpc register (WorkerInfo) returns (RegisterReply);
   rpc getPartitionRange (SampleKeyData) returns (PartitionRanges);
-  rpc getUpdatedWorkerInfo (Version) returns (WorkerInfo);
+  // rpc getUpdatedWorkerInfo (Version) returns (WorkerInfo);
   rpc canShutdownWorkerServer (google.protobuf.Empty) returns (CanShutdownWorkerServerReply);
 }


### PR DESCRIPTION
수정 사항: 
1. getUpdatedWorkerInfo 삭제(마스터 서버 코드랑 프로토에서 주석처리)
2. register 아래 방안으로 기능 업그레이드

기존 getUpdatedWorkerInfo를 register로 대체하는 방안 아이디어
-> register로 대체한다면, version Int값 overflow 안 나게 조심해야 할 듯
**register 기능 일부 수정해야 할 듯? 초기 등록 용도로 register 호출 시 버전 업을 시행하는 것이 맞고, 셔플 단계에서는 버전 업 없이 단순히 read 용으로만 workerInfos와 버전 갖고 오기(프로토에 register request에 등록용인지 셔플 용인지 bool 정보 추가해야 할 듯) → 이렇게 짜면 워커는 버전만 비교하면 문제되는 워커에게 지금 당장 getPartition 요구할지 안 할지 바로 알 수 있음 (+ 버전 Int 오버플로우 날 걱정도 없을 듯?

<등록용>
1. waiting request 조건 3개일 때, 기본 reply: workerInfo & version 반환 테스트 ⇒ 테스트 완료
3. kill 되었다 가정(재실행), 같은 ip 다른 port로 들어왔을 때 상황 테스트
2.1. simul) waiting request 이미 다 내보내고, 새로운 애 들어왔을 때 condition + 1의 version과 기존 겹치는 ip에서 port 값만 잘 교체 되었는 지 ⇒ 테스트 완료
2.2. simul) wating request 아직 덜 보낸 상태에서 kill 이후 새로운 애 들어왔을 때, 잘 수정되는 지 ⇒ 테스트 완료

<셔플용>(워커수: 3)
1. 죽음 없이 버전 3으로 셔플 진행 ⇒ 테스트 완료
1.1 3. 버전3으로 웨리포 닫힌 후 셔플 상태에서 죽음 발생 → 셔플 잘 되는 지 테스트 ⇒ 테스트 완료
2. 죽었다 살아난 워커가 웨리포 닫히기 전에 등록해서 버전 4인 상태로 셔플들 진행 ⇒ 테스트 완료